### PR TITLE
Fix logo path

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ app.on('ready', function () {
     width: 1050,
     'title-bar-style': 'hidden',
     fullscreen: false,
-    icon: './app/images/logo.png'
+    icon: './icon/logo.png'
   })
 
   main.maximize()


### PR DESCRIPTION
Electron app does not display the logo. This change points electron to an image that's actually available to represent the app.