### PR TITLE
Highlight search results, fix #9

### DIFF
--- a/app/components/mainview.js
+++ b/app/components/mainview.js
@@ -27,6 +27,8 @@ function MainView (opts) {
   var searchCursor = {}
 
   var doSearch = _.debounce(function (query) {
+    // Globally state for the current query, used for result hihglight
+    opts.query = query
     searchCursor = self.metadataDB.search(query, { pageSize: 50 }, updateList)
   }, 200)
 

--- a/app/components/paperbox.js
+++ b/app/components/paperbox.js
@@ -3,6 +3,7 @@ var inherits = require('inherits')
 var _ = require('lodash')
 var EventEmitter = require('events').EventEmitter
 var reader = require('../lib/reader.js')
+var highlight = require('../lib/highlight.js')
 
 inherits(PaperBox, EventEmitter)
 
@@ -27,6 +28,11 @@ function PaperBox (paper, opts) {
   title.innerHTML = self.paper.title
   author.innerHTML = self.paper.etalia()
   year.innerHTML = self.paper.year
+
+  if (opts.query) {
+    highlight(title, opts.query)
+    highlight(author, opts.query)
+  }
 
   var lensReader = null
 

--- a/app/components/paperrow.js
+++ b/app/components/paperrow.js
@@ -10,14 +10,16 @@ var loading = require('./loading.js')
 var articletype = require('./articletype.js')
 var textMinedTerms = require('./textminedterms.js')
 var overlay = require('./overlay.js')
+var highlight = require('../lib/highlight.js')
 var _ = require('lodash')
 
 inherits(PaperRow, EventEmitter)
 
-function PaperRow (paper) {
-  if (!(this instanceof PaperRow)) return new PaperRow(paper)
+function PaperRow (paper, opts) {
+  if (!(this instanceof PaperRow)) return new PaperRow(paper, opts)
   var self = this
-  this.paper = paper
+  self.paper = paper
+  self.opts = opts
 
   var lensReader = null
 
@@ -104,6 +106,10 @@ function PaperRow (paper) {
       ${self.loading.element}
     </div>
     `
+    if (self.opts.query) {
+      highlight(row.getElementsByClassName('paper-title')[0], self.opts.query)
+      highlight(row.getElementsByClassName('paper-author')[0], self.opts.query)
+    }
 
     row.onclick = function () {
       self.emit('click')

--- a/app/lib/highlight.js
+++ b/app/lib/highlight.js
@@ -1,0 +1,23 @@
+var find = require('findandreplacedomtext')
+var css = require('dom-css')
+
+// Highlights all the words in text inside a node
+function Highlight(node, text, wrapper) {
+  if (!Array.isArray(text)) {
+    text = text.split(' ')
+  }
+
+  if (!wrapper) {
+    wrapper = document.createElement('span')
+    css(wrapper, {
+      background: 'yellow',
+      color: 'black'
+    })
+  }
+
+  text.forEach(function(word) {
+    find(node, { find: RegExp(word,"gi"), wrap: wrapper })
+  })
+}
+
+module.exports = Highlight

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dom-css": "^2.0.0",
     "download": "^4.4.3",
     "electron-prebuilt": "^1.1.3",
+    "findandreplacedomtext": "^0.4.4",
     "install": "^0.6.1",
     "keymaster": "^1.6.2",
     "leveldown": "^1.4.6",


### PR DESCRIPTION
This add highlight capabilities to card results matching search query.
 
I'm introducing a new dependency [`findandreplacedomtext`](https://www.npmjs.com/package/findandreplacedomtext) that allows to wrap text in DOM with a Node.

To implement this, I'm (ab)using the opts object you are passing around on the updates. Probably this should be changed when implemented #23. I've also made some changes on `PaperRow` to mimic `PaperBox`'s API.

The highligh style its quite simple, feel free to suggest changes!