### PR TITLE
Show download icon in place of lens icon when paper fulltext isn't downloaded

### DIFF
--- a/app/components/downloadpaperbtn.js
+++ b/app/components/downloadpaperbtn.js
@@ -1,0 +1,49 @@
+var yo = require('yo-yo')
+var css = require('dom-css')
+var inherits = require('inherits')
+var EventEmitter = require('events').EventEmitter
+
+inherits(DownloadPaperButton, EventEmitter)
+
+function DownloadPaperButton(paper, opts) {
+  if (!(this instanceof DownloadPaperButton)) return new DownloadPaperButton(paper, opts)
+  var self = this
+
+  function button(type) {
+    var btn = yo`
+    <div class="clickable"></div>
+    `
+    css(btn, {
+      backgroundColor: 'rgb(43, 43, 51)',
+      '-webkit-mask': `url(./images/${type}.svg) center / contain no-repeat`,
+      display: 'block',
+      height: '20%',
+      padding: 0
+    })
+
+    return btn
+  }
+
+  var dlbtn = button('down_arrow')
+
+  dlbtn.onclick = function() {
+    paper.download(opts.fulltextSource.downloadPaperHTTP, self.load)
+  }
+
+  self.load = function() {
+    self.emit('downloaded')
+  }
+
+  self.element = yo`
+    ${dlbtn}
+  `
+
+  css(self.element, {
+    display: 'flex',
+    alignItems: 'center',
+    alignContent: 'center',
+    justifyContent: 'center'
+  })
+}
+
+module.exports = DownloadPaperButton

--- a/app/components/paperbox.js
+++ b/app/components/paperbox.js
@@ -3,6 +3,7 @@ var inherits = require('inherits')
 var _ = require('lodash')
 var EventEmitter = require('events').EventEmitter
 var reader = require('../lib/reader.js')
+var DownloadPaperBtn = require('./downloadpaperbtn.js')
 
 inherits(PaperBox, EventEmitter)
 
@@ -12,6 +13,8 @@ function PaperBox (paper, opts) {
   self.paper = paper
   self.opts = opts
 
+  var downloadPaper = DownloadPaperBtn(paper, opts)
+
   var box = document.createElement('div')
   box.className = 'paper paper-box clickable'
   var title = box.appendChild(document.createElement('div'))
@@ -19,6 +22,7 @@ function PaperBox (paper, opts) {
   var year = box.appendChild(document.createElement('div'))
   var overlay = box.appendChild(document.createElement('div'))
   var lens = overlay.appendChild(document.createElement('img'))
+  var downloadBtn = overlay.appendChild(downloadPaper.element)
   var bar = box.appendChild(document.createElement('div'))
   lens.src = './images/lens.png'
 
@@ -75,6 +79,10 @@ function PaperBox (paper, opts) {
     display: hasFulltextDownloaded ? 'block' : 'none'
   })
 
+  css(downloadBtn, {
+    width: '20%'
+  })
+
   self.layout = function () {
 
     var width = '160'
@@ -123,10 +131,9 @@ function PaperBox (paper, opts) {
     })
   }
 
-  self.downloaded = function (file) {
-    self.file = file.path
-    css(bar, {
-      width: '100%'
+  self.downloaded = function () {
+    css(lens, {
+      display: 'block'
     })
   }
 
@@ -153,6 +160,8 @@ function PaperBox (paper, opts) {
     lensReader.show()
     // TODO: destroy on close
   }
+
+  downloadPaper.on('downloaded', self.downloaded)
 
   self.box = box
 }

--- a/app/components/paperbox.js
+++ b/app/components/paperbox.js
@@ -80,7 +80,8 @@ function PaperBox (paper, opts) {
   })
 
   css(downloadBtn, {
-    width: '20%'
+    width: '20%',
+    display: hasFulltextDownloaded ? 'none' : 'block'
   })
 
   self.layout = function () {
@@ -134,6 +135,10 @@ function PaperBox (paper, opts) {
   self.downloaded = function () {
     css(lens, {
       display: 'block'
+    })
+
+    css(downloadBtn, {
+      display: 'none'
     })
   }
 

--- a/app/components/paperbox.js
+++ b/app/components/paperbox.js
@@ -69,8 +69,10 @@ function PaperBox (paper, opts) {
     justifyContent: 'center'
   })
 
+  var hasFulltextDownloaded = paper.assetPathByFilename('fulltext.xml')
   css(lens, {
-    width: '20%'
+    width: '20%',
+    display: hasFulltextDownloaded ? 'block' : 'none'
   })
 
   self.layout = function () {

--- a/app/lib/paper.js
+++ b/app/lib/paper.js
@@ -35,6 +35,20 @@ function Paper (doc, opts) {
     return paths
   }
 
+  self.assetPathByFilename = function (filename) {
+    var assetPaths = self.assetPaths()
+    if (!assetPaths.length) return false
+
+    var filenameInAssetDir = path.join(self.assetDir(), filename)
+
+    var match = assetPaths.filter(function(apath) {
+      return apath == filenameInAssetDir
+    })
+
+    // Assume only 1 match?
+    return match.length ? match[0] : false
+  }
+
   self.download = function (downloadfn, cb) {
     function done (a, b, c) {
       if (self.downloadsRunning == 0) cb(a, b, c)


### PR DESCRIPTION
Addresses #25 and fixes so that download icon is shown instead.