### PR TITLE
Allow install & build on linux systems

### DIFF
--- a/bin/package.js
+++ b/bin/package.js
@@ -86,6 +86,10 @@ function buildDarwin (cb) {
       console.log('OS X: Creating dmg...')
 
       var appDmg = require('appdmg')
+      if (!appDmg) {
+        throw "Can't create DMG without app-dmg!"
+      }
+
 
       var targetPath = path.join(DIST_PATH, BUILD_NAME + '.dmg')
       rimraf.sync(targetPath)

--- a/package.json
+++ b/package.json
@@ -44,13 +44,15 @@
     "yunodb": "github:blahah/yunodb"
   },
   "devDependencies": {
-    "appdmg": "^0.4.5",
     "cross-zip": "^2.1.3",
     "debug-menu": "^0.4.0",
     "electron-packager": "^7.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2"
+  },
+  "optionalDependencies": {
+    "appdmg": "^0.4.5"
   },
   "productName": "ScienceFair"
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "electron-packager": "^7.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "tar.gz": "^1.0.5"
   },
   "optionalDependencies": {
     "appdmg": "^0.4.5"


### PR DESCRIPTION
Hi all

First up, a warning: this is the first time I've ever touched NodeJS code, so the patch should be treated with due scepticism.

I tried running SF again today and saw that it still bails before installing on non-OSX systems. The attached patches allow one to build and run sciencefair on linux. Unfortunately  I can't get it to actually _do_ anything for some reason, but hopefully this helps someone with more skills get hacking (and I'll give it another go with node 6.2, which after R-ing TFM it seems is required).

Cheers, and thanks heaps for this (@blahah's demos look fantastic).
K
