### PR TITLE
Migrate to choo v4

### DIFF
--- a/app/effects/collection_remove.js
+++ b/app/effects/collection_remove.js
@@ -1,6 +1,6 @@
 const afterall = require('../lib/alldone')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   if (typeof data === 'string') data = [data]
 
   const removefromdb = afterall(data.length, () => {

--- a/app/effects/collection_scan.js
+++ b/app/effects/collection_scan.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const tags = {}
   var count = 0
   state.collection.docstore.createReadStream()

--- a/app/effects/collection_updatepaper.js
+++ b/app/effects/collection_updatepaper.js
@@ -6,7 +6,7 @@ const through = require('through2').obj
 
 const noop = () => {}
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const papers = isArray(data) ? data : [data]
   const docs = stream(papers)
   const keys = papers.filter(p => !p.collected).map(p => p.key)

--- a/app/effects/datasource_add.js
+++ b/app/effects/datasource_add.js
@@ -1,6 +1,6 @@
 const datasource = require('../lib/getdatasource')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   console.log('DATASOURCE ADD', data)
   if (data.key.length !== 64) {
     return done(new Error(`datasource keys must be 64 characters long, but ${data.key} has length ${data.key.length}`))

--- a/app/effects/datasource_remove.js
+++ b/app/effects/datasource_remove.js
@@ -1,6 +1,6 @@
 const datasource = require('../lib/getdatasource')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   datasource.del(data.key)
   done()
 }

--- a/app/effects/datasource_selector_toggle.js
+++ b/app/effects/datasource_selector_toggle.js
@@ -1,3 +1,3 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('datasources_setshown', !state.datasources.shown, done)
 }

--- a/app/effects/datasource_toggleactive.js
+++ b/app/effects/datasource_toggleactive.js
@@ -1,7 +1,7 @@
 const cloneDeep = require('lodash/cloneDeep')
 const datasource = require('../lib/getdatasource')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const entry = state.datasources.list.find(ds => ds.key === data.key)
 
   if (!entry) {

--- a/app/effects/datasource_update.js
+++ b/app/effects/datasource_update.js
@@ -1,11 +1,11 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (source, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.datasources.list)
 
-  const target = update.find(ds => ds.key === source.key)
+  const target = update.find(ds => ds.key === data.key)
 
-  if (target) Object.assign(target, source)
+  if (target) Object.assign(target, data)
 
   send('datasources_update', update, done)
 }

--- a/app/effects/datasources_setlist.js
+++ b/app/effects/datasources_setlist.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.datasources)
   Object.assign(update, { list: data })
 

--- a/app/effects/datasources_setloaded.js
+++ b/app/effects/datasources_setloaded.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.datasources)
   update.loaded = true
 

--- a/app/effects/datasources_setshown.js
+++ b/app/effects/datasources_setshown.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.datasources)
   update.shown = data
 

--- a/app/effects/download_add.js
+++ b/app/effects/download_add.js
@@ -1,7 +1,7 @@
 const datasource = require('../lib/getdatasource')
 const all = require('lodash/every')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const allready = all(data.forEach(p => p.ds.articleMetadataSynced()))
   const ntasks = data.length + allready ? 1 : 2
   const alldone = require('../lib/alldone')(ntasks, done)

--- a/app/effects/initialising_start.js
+++ b/app/effects/initialising_start.js
@@ -1,3 +1,3 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('initialising_set', true, done)
 }

--- a/app/effects/initialising_stop.js
+++ b/app/effects/initialising_stop.js
@@ -1,3 +1,3 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('initialising_set', false, done)
 }

--- a/app/effects/note_add.js
+++ b/app/effects/note_add.js
@@ -1,7 +1,7 @@
 const cloneDeep = require('lodash/cloneDeep')
 const uuid = require('uuid').v4
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   if (!data.message) return done()
   const update = cloneDeep(state.notes)
   const noteId = uuid()

--- a/app/effects/note_remove.js
+++ b/app/effects/note_remove.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.notes)
   if (update[data]) delete update[data]
 

--- a/app/effects/paper_addtag.js
+++ b/app/effects/paper_addtag.js
@@ -1,7 +1,7 @@
 const cloneDeep = require('lodash/cloneDeep')
 const uniq = require('lodash/uniq')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const alldone = require('../lib/alldone')(2, done)
 
 

--- a/app/effects/paper_removetag.js
+++ b/app/effects/paper_removetag.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const alldone = require('../lib/alldone')(3, done)
   const papers = state.selection.list
 

--- a/app/effects/paper_select.js
+++ b/app/effects/paper_select.js
@@ -4,7 +4,7 @@ const difference = require('lodash/difference')
 const uniq = require('lodash/uniq')
 const keyby = require('lodash/keyBy')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.selection)
   const results = state.results
 

--- a/app/effects/paper_select_show.js
+++ b/app/effects/paper_select_show.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('paper_select', data, (err) => {
     if (err) done(err)
     send('detail_show', null, done)

--- a/app/effects/read_none.js
+++ b/app/effects/read_none.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('reader_setstate', {
     visible: false,
     paper: null

--- a/app/effects/read_selection.js
+++ b/app/effects/read_selection.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('reader_setstate', {
     visible: true,
     paper: state.selection.list[0]

--- a/app/effects/results_receive.js
+++ b/app/effects/results_receive.js
@@ -2,7 +2,7 @@ const uniqBy = require('lodash/uniqBy')
 const sortBy = require('lodash/sortBy')
 const paper = require('../lib/getpaper')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const papers = data.hits.map(paper)
   papers.forEach(p => p.filesPresent(() => {}))
 

--- a/app/effects/search_addtag.js
+++ b/app/effects/search_addtag.js
@@ -1,7 +1,7 @@
 const uniq = require('lodash/uniq')
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const alldone = require('../lib/alldone')(2, done)
   const update = cloneDeep(state.currentsearch || {})
 

--- a/app/effects/search_clear.js
+++ b/app/effects/search_clear.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const alldone = require('../lib/alldone')(3, done)
 
   send('results_clear', 'collection', alldone)

--- a/app/effects/search_collection.js
+++ b/app/effects/search_collection.js
@@ -8,7 +8,7 @@ const parsedoc = doc => {
     : doc
 }
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   if (!state.collection) {
     return done(new Error('No local collection found (it may not have loaded yet)'))
   }

--- a/app/effects/search_datasources.js
+++ b/app/effects/search_datasources.js
@@ -3,7 +3,7 @@ const datasource = require('../lib/getdatasource')
 const bulk = require('bulk-write-stream')
 const pump = require('pump')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   if (!state.datasources.list || state.datasources.list.length === 0) {
     return done(
       new Error('No datasources found (they may not have loaded yet)')

--- a/app/effects/search_removetag.js
+++ b/app/effects/search_removetag.js
@@ -1,7 +1,7 @@
 const filter = require('lodash/filter')
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.currentsearch || {})
 
   update.tags = filter(state.currentsearch.tags, (t) => {

--- a/app/effects/search_setquerystring.js
+++ b/app/effects/search_setquerystring.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const queryparts = data.query.split('#')
   const newquery = queryparts[0].trim()
   const newtagquery = queryparts.length === 2 ? queryparts[1] || '' : null

--- a/app/effects/search_tagquerystripped.js
+++ b/app/effects/search_tagquerystripped.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const update = cloneDeep(state.currentsearch || {})
 
   update.tagquery = null

--- a/app/effects/search_update.js
+++ b/app/effects/search_update.js
@@ -1,7 +1,7 @@
 const uniq = require('lodash/uniq')
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   // query is an object containing:
   // `query` (String): text query
   // `tags` (Array): an array of 0 or more tags to filter by

--- a/app/effects/selection_clear.js
+++ b/app/effects/selection_clear.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   send('selection_set', {
     reference: null,
     list: [],

--- a/app/effects/tag_add.js
+++ b/app/effects/tag_add.js
@@ -1,7 +1,7 @@
 const includes = require('lodash/includes')
 const keys = require('lodash/keys')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const alldone = require('../lib/alldone')(3, done)
   const newtag = !includes(keys(state.tags.tags), data.tag)
 

--- a/app/effects/tag_addpaper.js
+++ b/app/effects/tag_addpaper.js
@@ -1,7 +1,7 @@
 const uniq = require('lodash/uniq')
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const papers = cloneDeep(state.tags.tags[data.tag]) || []
   const newPapers = uniq(papers.concat(state.selection.list.map(p => p.key)))
 

--- a/app/effects/tag_createnew.js
+++ b/app/effects/tag_createnew.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const tags = cloneDeep(state.tags.tags) || {}
 
   tags[data.tag] = data.paper.map(p => p.key)

--- a/app/effects/tag_removepaper.js
+++ b/app/effects/tag_removepaper.js
@@ -1,4 +1,4 @@
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const papers = state.tags.tags[data.tag]
 
   const removeidx = papers.indexOf(data.paper.key)

--- a/app/effects/tag_replace.js
+++ b/app/effects/tag_replace.js
@@ -1,6 +1,6 @@
 const cloneDeep = require('lodash/cloneDeep')
 
-module.exports = (data, state, send, done) => {
+module.exports = (state, data, send, done) => {
   const tags = cloneDeep(state.tags.tags) || {}
   if (data.papers.length > 0) {
     tags[data.tag] = data.papers.map(p => p.key)

--- a/app/index.js
+++ b/app/index.js
@@ -41,8 +41,8 @@ function start () {
 
     app.model(model)
 
-    app.router('/', (route) => [
-      route('/', require('./views/home'))
+    app.router([
+      ['/', require('./views/home')]
     ])
 
     const tree = app.start()

--- a/app/reducers/collection_setcount.js
+++ b/app/reducers/collection_setcount.js
@@ -1,4 +1,4 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return {
     collectioncount: data.count
   }

--- a/app/reducers/datasources_update.js
+++ b/app/reducers/datasources_update.js
@@ -1,4 +1,4 @@
-module.exports = data => {
+module.exports = (state, data) => {
   return {
     datasources: data
   }

--- a/app/reducers/detail_show.js
+++ b/app/reducers/detail_show.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { detailshown: true }
 }

--- a/app/reducers/detail_toggle.js
+++ b/app/reducers/detail_toggle.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { detailshown: !(state.detailshown) }
 }

--- a/app/reducers/downloads_update.js
+++ b/app/reducers/downloads_update.js
@@ -1,4 +1,4 @@
-module.exports = data => {
+module.exports = (state, data) => {
   return {
     downloads: data
   }

--- a/app/reducers/initialising_set.js
+++ b/app/reducers/initialising_set.js
@@ -1,4 +1,4 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return {
     initialising: data
   }

--- a/app/reducers/notes_set.js
+++ b/app/reducers/notes_set.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { notes: data }
 }

--- a/app/reducers/online_update.js
+++ b/app/reducers/online_update.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { online: data }
 }

--- a/app/reducers/reader_setstate.js
+++ b/app/reducers/reader_setstate.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { reader: data }
 }

--- a/app/reducers/result_replace.js
+++ b/app/reducers/result_replace.js
@@ -1,7 +1,7 @@
 const cloneDeep = require('lodash/cloneDeep')
 const isArray = require('lodash/isArray')
 
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   const results = cloneDeep(state.results)
   const resultkeys = results.map(r => r.key)
 

--- a/app/reducers/results_replace.js
+++ b/app/reducers/results_replace.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { results: data }
 }

--- a/app/reducers/search_populate.js
+++ b/app/reducers/search_populate.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { populatesearch: data }
 }

--- a/app/reducers/search_populatedone.js
+++ b/app/reducers/search_populatedone.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { populatesearch: null }
 }

--- a/app/reducers/search_trickle.js
+++ b/app/reducers/search_trickle.js
@@ -1,3 +1,3 @@
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return { currentsearch: data }
 }

--- a/app/reducers/selection_set.js
+++ b/app/reducers/selection_set.js
@@ -8,7 +8,7 @@
 //     Paper{}
 //   ]
 // }
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return {
     selection: data
   }

--- a/app/reducers/tags_replace.js
+++ b/app/reducers/tags_replace.js
@@ -2,7 +2,7 @@
 // which should be an object where each:
 //   key = the tag
 //   value = array of paper IDs with this tag
-module.exports = (data, state) => {
+module.exports = (state, data) => {
   return {
     tags: {
       tags: data,

--- a/app/views/footer.js
+++ b/app/views/footer.js
@@ -68,6 +68,7 @@ const style = css`
 `
 
 module.exports = (state, prev, send) => {
+  console.log('footer state', state)
   const downloads = html`
 
   <div class="${style.left} ${style.part}">

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bulk-write-stream": "^1.1.3",
     "bytes": "^2.4.0",
     "cache-element": "^2.0.0",
-    "choo": "^3.3.0",
+    "choo": "^4.1.0",
     "copy-paste": "^1.3.0",
     "csjs": "^1.0.5",
     "csjs-inject": "^1.0.0",

--- a/test/collection_updatepaper.js
+++ b/test/collection_updatepaper.js
@@ -34,7 +34,7 @@ test('effect: collection_updatepaper', (t) => {
 
     data.document.tags = ['changed']
 
-    effect(data, state, null, (err) => {
+    effect(state, data, null, (err) => {
       t.error(err, 'update getpaper')
 
       if (err) {

--- a/test/search_collection.js
+++ b/test/search_collection.js
@@ -41,7 +41,7 @@ test('effect: search_collection', (t) => {
         cb()
       }
 
-      effect(data, state, send, (err) => {
+      effect(state, data, send, (err) => {
         t.error(err, 'run tag filter')
 
         if (err) {
@@ -66,7 +66,7 @@ test('effect: search_collection', (t) => {
         cb()
       }
 
-      effect(data, state, send, (err) => {
+      effect(state, data, send, (err) => {
         t.error(err, 'run search')
 
         if (err) {
@@ -91,7 +91,7 @@ test('effect: search_collection', (t) => {
         cb()
       }
 
-      effect(data, state, send, (err) => {
+      effect(state, data, send, (err) => {
         t.error(err, 'run tag filter')
 
         if (err) {


### PR DESCRIPTION
Migrated to choo v4.

This involved a bunch of API changes, loosely document in the [choo changelog](https://github.com/yoshuawuyts/choo/blob/master/CHANGELOG.md#400-the-routing-patch). For anyone walking this path later, the best resource was the changelog combined with the [latest v4 README](https://github.com/yoshuawuyts/choo/tree/eea83d22736337b378710fd4480f3b150dc08ffc) which documents the v4 API with examples.