### PR TITLE
readme: fix dev install instructions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "../node_modules/.bin/electron index.js",
     "dev": "DEBUG='sciencefair' SCIENCEFAIR_DEVMODE=TRUE ../node_modules/.bin/electron index.js",
-    "postinstall": "../node_modules/.bin/electron-rebuild"
+    "postinstall": "npm run rebuild",
+    "rebuild": "../node_modules/.bin/electron-rebuild"
   },
   "engines": {
     "node": "7.x"


### PR DESCRIPTION
There is no app/package.json rebuild script as discussed in the readme.

Im not really an electron user, but from reading the dual package.json link it seems this electron command in the root package.json postinstall will install the app deps rather than cding.

Im not sure if there still some rebuild step needed though.