### PR TITLE
Disable BitTorrent DHT

### DIFF
--- a/app/client/lib/datasource.js
+++ b/app/client/lib/datasource.js
@@ -138,7 +138,8 @@ function Datasource (key, opts) {
           port: port,
           live: true,
           upload: true,
-          download: true
+          download: true,
+          dht: false
         })
       })
     })
@@ -301,7 +302,8 @@ function Datasource (key, opts) {
           port: port,
           live: true,
           upload: true,
-          download: true
+          download: true,
+          dht: false
         })
 
         self.articlesswarm.on('connection', (peer, type) => {


### PR DESCRIPTION
To workaround the firewall blocking issues. We should move to our own DHT soon as well.