### PR TITLE
Esc key

### DIFF
--- a/app/client/keybindings.js
+++ b/app/client/keybindings.js
@@ -1,9 +1,15 @@
 const Mousetrap = require('mousetrap')
+const {BrowserWindow} = require('electron').remote
 
 module.exports = (state, bus) => {
+
+  // ESC
   Mousetrap.bind('esc', () => {
     if (state.datasources.shown) {
       bus.emit('datasources:toggle-shown')
+    } else {
+      const win = BrowserWindow.getFocusedWindow()
+      win.setFullScreen(false)
     }
   })
 

--- a/app/client/keybindings.js
+++ b/app/client/keybindings.js
@@ -1,0 +1,10 @@
+const Mousetrap = require('mousetrap')
+
+module.exports = (state, bus) => {
+  Mousetrap.bind('esc', () => {
+    if (state.datasources.shown) {
+      bus.emit('datasources:toggle-shown')
+    }
+  })
+
+}

--- a/app/client/run.js
+++ b/app/client/run.js
@@ -26,6 +26,8 @@ app.use(require('./models/search'))
 app.use(require('./models/selection'))
 app.use(require('./models/tags'))
 
+app.use(require('./keybindings'))
+
 app.route('#', require('./views/start'))
 app.route('#home', require('./views/home'))
 app.route('#initial', require('./views/initial'))

--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "lowdb": "^0.16.2",
     "matched": "^0.4.3",
     "mkdirp": "^0.5.1",
+    "mousetrap": "^1.6.1",
     "multi-read-stream": "^2.0.0",
     "node-static": "^0.7.7",
     "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "rimraf": "^2.5.2",
     "standard": "^10.0.2",
     "temporary": "^0.0.8"
+  },
+  "dependencies": {
+    "electron-default-menu": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "rimraf": "^2.5.2",
     "standard": "^10.0.2",
     "temporary": "^0.0.8"
-  },
-  "dependencies": {
-    "electron-default-menu": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Add Mousetrap and a file for Keybindings, with access to app state and event emitter
- Closes #68 - closes the modal on Esc (if open)
- Closes #135  - Exits fullscreen mode on Esc (if Modal is not open)

Are there any other modals/dialogs? Anything else I'm missing?