### PR TITLE
Ensure paper progress elements stay in sync

### DIFF
--- a/app/client/lib/paper.js
+++ b/app/client/lib/paper.js
@@ -82,7 +82,7 @@ function Paper (data) {
       debug('progress stats', self.title, stats)
       if (stats.progress > 0) self.collected = true
       self.progress = stats.progress * 100
-      self.emit('progress', self.progress)
+      self.emit('progress', self.minprogress())
       self.progresschecked = true
       cb(null, self.progress, true)
     })
@@ -99,6 +99,8 @@ function Paper (data) {
     self.collected = true
     self.downloading = true
 
+    self.emit('progress', self.minprogress())
+
     const done = () => {
       if (!self.downloading) return
       debug('downloaded', self.key)
@@ -109,7 +111,7 @@ function Paper (data) {
 
     download.on('progress', data => {
       self.progress = data.progress * 100
-      self.emit('progress', self.progress)
+      self.emit('progress', self.minprogress())
       if (self.progress === 100) done()
     })
 

--- a/app/client/models/paper.js
+++ b/app/client/models/paper.js
@@ -4,6 +4,7 @@ module.exports = (state, bus) => {
   const render = () => bus.emit('renderer:render')
 
   const selectshow = data => {
+    data.paper.filesPresent(() => {})
     bus.emit('selection:update', data)
     bus.emit('detail:show')
   }

--- a/app/client/run.js
+++ b/app/client/run.js
@@ -3,7 +3,7 @@ const app = choo({ href: false })
 
 app.use(require('choo-asyncify'))
 app.use(require('./models/error'))
-app.use(require('choo-log')())
+app.use(require('choo-devtools')())
 
 app.use(require('./models/renderer'))
 

--- a/app/package.json
+++ b/app/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "byte-stream": "^2.1.0",
     "bytes": "^2.4.0",
-    "cache-component": "5.0.0-1",
-    "choo": "v6.0.0-1",
+    "cache-component": "^5.2.0",
+    "choo": "^6.11.0",
     "choo-asyncify": "^0.0.2",
-    "choo-log": "7.0.0-0",
+    "choo-devtools": "^2.5.1",
     "copy-paste": "^1.3.0",
     "csjs": "^1.0.5",
     "csjs-inject": "^1.0.0",


### PR DESCRIPTION
This fixes a bug where, when connectivity is poor, the paper progress bar takes a while to sync up with the download button progress bar.