### PR TITLE
Update the json loader for unkown authors.

### DIFF
--- a/app/client/lib/paper.js
+++ b/app/client/lib/paper.js
@@ -27,7 +27,7 @@ function Paper (data) {
 
   self.loadBib = () => {
     self.title = htmlify(data.title || 'no title')
-    self.author = data.author || 'unknown'
+    self.author = data.author || { 'surname': 'unknown', 'given-names': 'unknown' }
     self.abstract = htmlify(data.abstract || 'no abstract given')
     self.date = data.date || { year: 'unknown ', month: 'unknown', day: 'unknown'}
     self.tags = data.tags || []


### PR DESCRIPTION
It was creating a string of 'unkown' for the author entry rather than a dictionary containing surname and given-names as is expected later in the code. In creating the PMC database I ran across this as an error. I am pretty sure I got the keys correct given the code in app/client/lib/paper.js at line 133. That was where I first noticed the error and hopefully this is enough to allow some slightly less clean datasets to be used.

P.S. [Here](https://www.ncbi.nlm.nih.gov/pubmed/30356604) is the first article I found that caused this issue. It is a correction so the PubMed database doesn't have a listed author for it.