### PR TITLE
Fix error due to outdated electron-updater.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,7 @@
     "electron-debug": "^2.0.0",
     "electron-default-menu": "^1.0.1",
     "electron-log": "^2.0.0",
-    "electron-updater": "^3.1.2",
+    "electron-updater": "^4.0.0",
     "end-of-stream": "^1.1.0",
     "findandreplacedomtext": "^0.4.4",
     "folder-walker": "^3.1.0",


### PR DESCRIPTION
The current version of electron-builder complains that electron-updater should be version 4.0.0 or higher. This makes it so. While the application can be run in dev-mode without this change it is unable to build in distribution mode without it.