### PR TITLE
Add missing acorn dependency.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "acorn": "^6.0.4",
     "byte-stream": "^2.1.0",
     "bytes": "^3.0.0",
     "cache-component": "^5.2.0",


### PR DESCRIPTION
The build was giving an error that there was a missing peer of acorn ^6.0.0. This appears to remove that error.