### PR TITLE
Correct patch for missing author data

### DIFF
--- a/app/client/lib/paper.js
+++ b/app/client/lib/paper.js
@@ -27,7 +27,7 @@ function Paper (data) {
 
   self.loadBib = () => {
     self.title = htmlify(data.title || 'no title')
-    self.author = data.author || { 'surname': 'unknown', 'given-names': 'unknown' }
+    self.author = data.author || [{ 'surname': 'unknown', 'given-names': 'unknown' }]
     self.abstract = htmlify(data.abstract || 'no abstract given')
     self.date = data.date || { year: 'unknown ', month: 'unknown', day: 'unknown'}
     self.tags = data.tags || []

--- a/app/client/lib/paper.js
+++ b/app/client/lib/paper.js
@@ -27,7 +27,7 @@ function Paper (data) {
 
   self.loadBib = () => {
     self.title = htmlify(data.title || 'no title')
-    self.author = data.author || 'unknown'
+    self.author = data.author || { 'surname': 'unknown', 'given-names': 'unknown' }
     self.abstract = htmlify(data.abstract || 'no abstract given')
     self.date = data.date || { year: 'unknown ', month: 'unknown', day: 'unknown'}
     self.tags = data.tags || []


### PR DESCRIPTION
This has the true fix for authors that are missing data. It needed to be a list of author objects, not a singular author object.